### PR TITLE
runner: Set the BASH_XTRACEFD and PS4 variables explicitly

### DIFF
--- a/lib/bashcov/runner.rb
+++ b/lib/bashcov/runner.rb
@@ -14,9 +14,11 @@ module Bashcov
 
       @xtrace = Xtrace.new
       fd = @xtrace.file_descriptor
-      @command = "BASH_XTRACEFD=#{fd} PS4='#{Xtrace::PS4}' #{@command}"
       options = {:in => :in, fd => fd} # bind fds to the child process
       options.merge!({out: '/dev/null', err: '/dev/null'}) if Bashcov.options.mute
+
+      ENV["BASH_XTRACEFD"] = "#{fd}"
+      ENV["PS4"] = "#{Xtrace::PS4}"
 
       command_pid = Process.spawn @command, options # spawn the command
       xtrace_thread = Thread.new { @xtrace.read } # start processing the xtrace output


### PR DESCRIPTION
Set the BASH_XTRACEFD and PS4 variables explicitly as opposed
to setting them on the command line. If they are the first element
on the command line, argv[0] will not be "bash" and bash will
run in posix-compatible mode, which isn't always the desired
behaviour.

No tests can be provided, as the interaction between BASH_XTRACEFD
and bash-only syntax on BSD is flakey at best, which means that
tests will only pass a part of the time.

Fixes #5
